### PR TITLE
Fix docs IDs and format config

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -2,8 +2,5 @@
   "root": true,
   "parser": "@typescript-eslint/parser",
   "plugins": ["@typescript-eslint"],
-  "extends": [
-    "eslint:recommended",
-    "plugin:@typescript-eslint/recommended"
-  ]
+  "extends": ["eslint:recommended", "plugin:@typescript-eslint/recommended"]
 }

--- a/docs/index.html
+++ b/docs/index.html
@@ -372,7 +372,7 @@
                         - Optional configuration object
                       </li>
                     </ul>
-                    <h4 id="options" class="text-lg font-semibold text-gray-800 mt-4">
+                    <h4 id="parse-options" class="text-lg font-semibold text-gray-800 mt-4">
                       ParseOptions
                     </h4>
                     <ul class="list-disc pl-5 text-gray-600">
@@ -408,7 +408,7 @@
                       </li>
                     </ul>
 
-                    <h4 id="options" class="text-lg font-semibold text-gray-800 mt-4">
+                    <h4 id="parsed-value" class="text-lg font-semibold text-gray-800 mt-4">
                       ParsedValue
                     </h4>
                     <ul class="list-disc pl-5 text-gray-600">
@@ -439,7 +439,9 @@
                       </li>
                     </ul>
 
-                    <h4 id="options" class="text-lg font-semibold text-gray-800 mt-4">Match</h4>
+                    <h4 id="match-options" class="text-lg font-semibold text-gray-800 mt-4">
+                      Match
+                    </h4>
                     <ul class="list-disc pl-5 text-gray-600">
                       <li>
                         <code class="text-sm bg-gray-100 px-1.5 py-0.5 rounded">value: number</code>


### PR DESCRIPTION
## Summary
- update duplicate `options` ids to `parse-options`, `parsed-value`, and `match-options`
- run Prettier formatter from package.json to format `.eslintrc.json`

## Testing
- `pnpm test`
- `pnpm lint`


------
https://chatgpt.com/codex/tasks/task_e_683fbc5d553c83208e639ecadfbfb2ce